### PR TITLE
Fix for visible water tile edges in the bright style

### DIFF
--- a/styles/bright-v9-cdn.json
+++ b/styles/bright-v9-cdn.json
@@ -324,37 +324,6 @@
             "interactive": true
         },
         {
-            "id": "water_offset",
-            "paint": {
-                "fill-color": "white",
-                "fill-opacity": 0.3,
-                "fill-translate": [
-                    0,
-                    2.5
-                ]
-            },
-            "metadata": {
-                "mapbox:group": "1444849382550.77"
-            },
-            "interactive": true,
-            "ref": "water"
-        },
-        {
-            "id": "water_pattern",
-            "paint": {
-                "fill-translate": [
-                    0,
-                    2.5
-                ],
-                "fill-pattern": "wave"
-            },
-            "metadata": {
-                "mapbox:group": "1444849382550.77"
-            },
-            "interactive": true,
-            "ref": "water"
-        },
-        {
             "interactive": true,
             "minzoom": 11,
             "metadata": {


### PR DESCRIPTION
Based on the wontfix decision in https://github.com/osm2vectortiles/osm2vectortiles/issues/300#issuecomment-235352622, the original mapbox wave pattern from the bright style needs to be removed. Otherwise ugly water tile edges would become visible.
